### PR TITLE
Ability to import "connectionStrings" values as easily as "appSettings"

### DIFF
--- a/src/Alt.Composition.Settings/Alt.Composition.Settings.csproj
+++ b/src/Alt.Composition.Settings/Alt.Composition.Settings.csproj
@@ -65,6 +65,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConnectionStringAttribute.cs" />
+    <Compile Include="Hosting\ConnectionStringsExportDescriptorProvider.cs" />
     <Compile Include="Hosting\SettingsExportDescriptorProvider.cs" />
     <Compile Include="Hosting\SettingsExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Alt.Composition.Settings/ConnectionStringAttribute.cs
+++ b/src/Alt.Composition.Settings/ConnectionStringAttribute.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Composition;
+
+namespace Alt.Composition
+{
+    /// <summary>
+    /// Marks an export or import as corresponding to an application-level connection string.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+    [MetadataAttribute]
+    public class ConnectionStringAttribute : Attribute
+    {
+        private readonly string _name;
+
+        /// <summary>
+        /// Construct a <see cref="ConnectionStringAttribute"/>.
+        /// </summary>
+        /// <param name="name">The name of the connection string in the application's configuration file.</param>
+        /// <remarks>
+        /// An import marked with:
+        /// <code>
+        ///     [ConnectionString("someName")]
+        /// </code>
+        /// will be provided with a value from App.config or Web.config's &lt;connectionStrings&gt; collection
+        /// like:
+        /// <code>
+        ///     &lt;add name="someName" connectionString="..." providerName="..." /&gt;
+        /// </code>
+        /// as long as the type is either <see cref="System.String">string</see> or one of the provider-specific
+        /// subclasses of <see cref="System.Data.Common.DbConnectionStringBuilder">DbConnectionStringBuilder</see>.
+        /// </remarks>
+        public ConnectionStringAttribute(string name)
+        {
+            _name = name;
+        }
+
+        /// <summary>
+        /// The name of the connection string in App.config or Web.config.
+        /// </summary>
+        public string ConnectionStringName { get { return _name; } }
+    }
+}

--- a/src/Alt.Composition.Settings/Hosting/ConnectionStringsExportDescriptorProvider.cs
+++ b/src/Alt.Composition.Settings/Hosting/ConnectionStringsExportDescriptorProvider.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition.Hosting.Core;
+using System.Configuration;
+using System.Data.Common;
+using System.Linq;
+
+namespace Alt.Composition.Hosting
+{
+    class ConnectionStringsExportDescriptorProvider : ExportDescriptorProvider
+    {
+        private const string NameKey = "ConnectionStringName";
+
+        public override IEnumerable<ExportDescriptorPromise> GetExportDescriptors(CompositionContract contract, DependencyAccessor descriptorAccessor)
+        {
+            if (contract == null) throw new ArgumentNullException("contract");
+            if (descriptorAccessor == null) throw new ArgumentNullException("descriptorAccessor");
+
+            string name;
+            CompositionContract unwrapped;
+
+            var connectionStringSettings = ConfigurationManager.ConnectionStrings.OfType<ConnectionStringSettings>().ToArray();
+
+            if (!contract.TryUnwrapMetadataConstraint(NameKey, out name, out unwrapped) ||
+                !unwrapped.Equals(new CompositionContract(unwrapped.ContractType)) ||
+                !(unwrapped.ContractType == typeof(string) || typeof(DbConnectionStringBuilder).IsAssignableFrom(unwrapped.ContractType)) ||
+                !connectionStringSettings.Any(cs => cs.Name == name))
+                yield break;
+
+            var stringValue = connectionStringSettings.Single(cs => cs.Name == name).ConnectionString;
+            object value = stringValue;
+
+            if (contract.ContractType != typeof(string))
+            {
+                var stringBuilder = Activator.CreateInstance(contract.ContractType) as DbConnectionStringBuilder;
+                if (stringBuilder == null) yield break;
+                stringBuilder.ConnectionString = stringValue;
+                value = stringBuilder;
+            }
+
+            yield return new ExportDescriptorPromise(
+                    contract,
+                    "System.Configuration.ConfigurationManager.ConnectionStrings",
+                    true,
+                    NoDependencies,
+                    _ => ExportDescriptor.Create((c, o) => value, NoMetadata));
+        }
+    }
+}

--- a/src/Alt.Composition.Settings/Hosting/SettingsExtensions.cs
+++ b/src/Alt.Composition.Settings/Hosting/SettingsExtensions.cs
@@ -18,5 +18,17 @@ namespace Alt.Composition.Hosting
             if (configuration == null) throw new ArgumentNullException("configuration");
             return configuration.WithProvider(new SettingsExportDescriptorProvider());
         }
+
+        /// <summary>
+        /// Enables the use of the [ConnectionString("name")] syntax on imports to retrieve values from *.config.
+        /// </summary>
+        /// <param name="configuration">The container configuration.</param>
+        /// <returns>Container configuration allowing method chaining.</returns>
+        /// <exception cref="ArgumentNullException">The given <c>ContainerConfiguration</c> instance was null.</exception>
+        public static ContainerConfiguration WithConnectionStrings(this ContainerConfiguration configuration)
+        {
+            if (configuration == null) throw new ArgumentNullException("configuration");
+            return configuration.WithProvider(new ConnectionStringsExportDescriptorProvider());
+        }
     }
 }

--- a/test/Alt.Settings.Tests/Alt.Settings.Tests.csproj
+++ b/test/Alt.Settings.Tests/Alt.Settings.Tests.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Composition.TypedParts">
       <HintPath>..\..\packages\Microsoft.Composition.1.0.16\lib\net45\System.Composition.TypedParts.dll</HintPath>
     </Reference>
+    <Reference Include="System.Data" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -66,6 +67,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ApplicationSettingsTests.cs" />
+    <Compile Include="ConfigurationStringsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Alt.Settings.Tests/Alt.Settings.Tests.dll.config
+++ b/test/Alt.Settings.Tests/Alt.Settings.Tests.dll.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+  <connectionStrings>
+    <add name="First" connectionString="Server=.\SQLEXPRESS;Database=First;Integrated Security=SSPI" providerName="System.Data.SqlClient" />
+    <add name="Second" connectionString="Server=.\SQLEXPRESS;Database=Second;Integrated Security=SSPI" providerName="System.Data.SqlClient" />
+  </connectionStrings>
   <appSettings>
     <add key="aString" value="Hello, World!"/>
     <add key="aBoolean" value="true"/>

--- a/test/Alt.Settings.Tests/ConfigurationStringsTests.cs
+++ b/test/Alt.Settings.Tests/ConfigurationStringsTests.cs
@@ -1,0 +1,51 @@
+﻿using Alt.Composition;
+using Alt.Composition.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Composition;
+using System.Composition.Hosting;
+using System.Data.SqlClient;
+
+namespace Alt.Settings.Tests
+{
+    [TestClass, DeploymentItem("Alt.Settings.Tests.dll.config")]
+    public class ConfigurationStringsTests
+    {
+        [Export]
+        public class StringImporter
+        {
+            [Import, ConnectionString("First")]
+            public string AConnectionString { get; set; }
+        }
+
+        [TestMethod]
+        public void AConnectionStringCanBeReadAsString()
+        {
+            var instance = ComposeWithConnectionStrings<StringImporter>();
+            Assert.AreEqual(@"Server=.\SQLEXPRESS;Database=First;Integrated Security=SSPI", instance.AConnectionString);
+        }
+
+        [Export]
+        public class DbConnectionStringBuilderImporter
+        {
+            [Import, ConnectionString("Second")]
+            public SqlConnectionStringBuilder AConnectionStringBuilder { get; set; }
+        }
+
+        [TestMethod]
+        public void AConnectionStringCanBeReadAsSqlConnectionStringBuilder()
+        {
+            var instance = ComposeWithConnectionStrings<DbConnectionStringBuilderImporter>();
+            Assert.IsNotNull(instance);
+            Assert.AreEqual(@"Data Source=.\SQLEXPRESS;Initial Catalog=Second;Integrated Security=True", instance.AConnectionStringBuilder.ToString());
+        }
+
+        private TPart ComposeWithConnectionStrings<TPart>()
+        {
+            return new ContainerConfiguration()
+                .WithPart<TPart>()
+                .WithConnectionStrings()
+                .CreateContainer()
+                .GetExport<TPart>();
+        }
+    }
+}


### PR DESCRIPTION
Adds the "ConnectionString" attribute and ".WithConnectionStrings()" extension method to allow values from the "connectionStrings" section of the .config file to be imported as simply as the "appSettings" section values.
